### PR TITLE
Modify webbook chapter number bottom margin

### DIFF
--- a/assets/styles/components/_section-titles.scss
+++ b/assets/styles/components/_section-titles.scss
@@ -57,6 +57,12 @@ $chapter-number-font-size: (
 $chapter-number-align: left !default;
 $chapter-number-after-content: '\00A0' !default;
 
+$chapter-number-margin-bottom: (
+  epub: 1em,
+  prince: 0.5cm,
+  web: 0.25em // Changed from 1em
+) !default;
+
 $chapter-number-border-bottom-style: solid !default;
 $chapter-number-border-bottom-width: (epub: 1px, prince: 1px, web: 1px) !default;
 


### PR DESCRIPTION
There’s actually a Buckram variable to control the bottom margin of the chapter number called `$chapter-number-margin-bottom` and it accepts a [map](https://sass-lang.com/documentation/values/maps/) value for the different formats, so you can modify the web margin without impacting PDF or EPUB.